### PR TITLE
Use Gradle application plugin for run task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: "java"
 apply plugin: "idea"
 apply plugin: 'groovy'
 apply plugin: 'java-library-distribution'
+apply plugin: 'application'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -15,6 +16,10 @@ java {
 
 group = "canfield.josh"
 version = "1.1"
+
+application {
+    mainClass = 'canfield.bia.ServiceMain'
+}
 
 project.ext {
     jackson = [version: "1.9.9"]
@@ -90,6 +95,10 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED'
 
     enableAssertions = true
+}
+tasks.named('run') {
+    args 'start'
+    workingDir = file('src/main/dist')
 }
 tasks.named('wrapper') {
     gradleVersion = '8.7'


### PR DESCRIPTION
## Summary
- apply Gradle application plugin and set ServiceMain as main class
- configure default run args and working directory via application plugin

## Testing
- `./gradlew test`
- `./gradlew run --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a9f7c68f88832ba78f9fb79bf1bcee