### PR TITLE
UI/penalty serving rec 5min end

### DIFF
--- a/src/main/dist/web/css/index.css
+++ b/src/main/dist/web/css/index.css
@@ -140,8 +140,17 @@ h2 { font-size: 28px; letter-spacing: 0.08em; color: var(--muted); text-transfor
 
 /* Penalties */
 .penalties .table { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
-.penalties .table > tbody > tr > td, .penalties .table > thead > tr > th { border-color: rgba(255,255,255,0.06); }
+.penalties .table { width: 100%; }
+.penalties .table > tbody > tr > td,
+.penalties .table > thead > tr > th,
+.penalties .table > tbody > tr > th { border-color: rgba(255,255,255,0.06); text-align: center; vertical-align: middle; white-space: nowrap; }
+.penalties .table td .pn[data-serving]:not([data-serving=""])::after { content: " (" attr(data-serving) ")"; }
 .penalties a.btn.btn-primary { --btn-primary-bg: var(--accent); --btn-primary-bg-2: var(--accent); --btn-primary-shadow: none; }
+
+/* Placeholder rows for penalties: muted look, non-interactive */
+.penalties tbody.placeholders tr.placeholder td:last-child { /* hide action column visually for placeholders */
+    visibility: hidden;
+}
 
 .progress { background: rgba(255,255,255,0.06); border-radius: 10px; border: 1px solid var(--border); }
 .progress-bar { background: linear-gradient(90deg, var(--accent), var(--accent-2)); box-shadow: 0 0 12px rgba(76,201,240,0.45); }

--- a/src/main/dist/web/css/index.css
+++ b/src/main/dist/web/css/index.css
@@ -53,9 +53,12 @@ img.navbar-brand {
 #clock_box .clock .digits {
     width: 210px;
     height: 75px;
-    padding-left: 5px;
     margin: auto;
     border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
 }
 
 #clock_box .clock .digit.minutes.ones::after {
@@ -69,6 +72,108 @@ img.navbar-brand {
     line-height: 60px;
     float: left;
 }
+
+/* v2 markup: single text node for clock */
+#clock_box .clock .clock-text {
+    color: #af0e0e;
+    font-size: 70px;
+    line-height: 1;
+    text-align: center;
+}
+
+/* ---- merged from modern.css (consolidated to single stylesheet) ---- */
+/* Tokens and base */
+:root {
+    --bg: #0b1020;
+    --bg-elev: #11182e;
+    --panel: #0f1530;
+    --text: #e6e9ef;
+    --muted: #a5b0c2;
+    --accent: #337ab7;
+    --accent-2: #337ab7;
+    --warn: #ffb703;
+    --danger: #ef476f;
+    --success: #06d6a0;
+    --led: #ff3b30;
+    --led-amber: #ffe66d;
+    --glass: rgba(255,255,255,0.06);
+    --border: rgba(255,255,255,0.12);
+    --shadow: 0 10px 30px rgba(0,0,0,0.35);
+}
+
+html, body { background: radial-gradient(1200px 800px at 20% 10%, #10224a, var(--bg)); color: var(--text); }
+body.buzzer { animation: buzzerPulse 0.6s ease-in-out 0s infinite alternate; }
+@keyframes buzzerPulse { from { background-color: #2b0b0b; } to { background-color: #5b1010; } }
+
+.container { background: linear-gradient(180deg, var(--glass), transparent); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); padding: 20px 24px 28px; }
+.navbar.navbar-default { background: linear-gradient(180deg, #0f1530, #0c1228); border: 1px solid var(--border); border-radius: 12px; }
+.navbar-default .navbar-brand, .navbar-default .navbar-nav>li>a, .navbar-default .navbar-btn { color: var(--text); }
+.navbar.navbar-default .navbar-brand, .navbar.navbar-default .navbar-nav>li>a { background: transparent !important; }
+img.navbar-brand { display: block; height: 97px; width: auto; }
+.navbar-btn#buzzer { background: var(--warn); border: none; color: #1b1b1b; font-weight: 700; }
+.btn.btn-primary { background: linear-gradient(180deg, var(--btn-primary-bg, var(--accent)), var(--btn-primary-bg-2, var(--accent-2))); border: none; box-shadow: var(--btn-primary-shadow, 0 6px 14px rgba(76,201,240,0.25)); }
+.navbar .btn.btn-primary, .navbar-btn.btn-primary { --btn-primary-bg: var(--accent); --btn-primary-bg-2: var(--accent); --btn-primary-shadow: none; font-weight: 700; }
+
+/* Layout & cards */
+#home, #away, #clock_box { padding: 8px 10px; }
+h2 { font-size: 28px; letter-spacing: 0.08em; color: var(--muted); text-transform: uppercase; }
+.score, .shots { background: var(--panel); border: 1px solid var(--border); border-radius: 16px; padding: 14px; box-shadow: var(--shadow); }
+.section-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .08em; margin-bottom: 6px; }
+
+/* Digits look */
+.digits { background: #04070f; border: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 0 30px rgba(0,0,0,0.8), 0 0 20px rgba(76,201,240,0.05); }
+#clock_box .clock .digit, #home .score .digit, #away .score .digit, #period .digits .digit { text-shadow: 0 0 12px rgba(255,100,100,0.45), 0 0 3px rgba(255,255,255,0.15); }
+#clock_box .clock .digit { color: var(--led); }
+#home .score .digit, #away .score .digit { color: var(--led-amber); }
+.score .score-text { width: 100%; text-align: center; font-variant-numeric: tabular-nums; font-size: 80px; line-height: 1; color: var(--led-amber); }
+
+.shots-counter { display: inline-block; min-width: 54px; padding: 6px 10px; text-align: center; font-size: 28px; line-height: 1; color: var(--text); background: #0d1328; border: 1px solid var(--border); border-radius: 12px; }
+
+/* Clock */
+#clock_box .clock { margin-top: 12px; }
+#clock-actions .btn { color: var(--text); background: #1d2540; border: 1px solid var(--border); border-radius: 12px; padding: 6px 10px; }
+#clock_box .clock .clock-text { display: block; width: 100%; text-align: center; font-variant-numeric: tabular-nums; font-size: 70px; line-height: 60px; color: var(--led); text-shadow: 0 0 12px rgba(255,100,100,0.45), 0 0 3px rgba(255,255,255,0.15); }
+
+/* Period */
+#period-block { display: flex; align-items: center; gap: 10px; justify-content: center; margin-top: 10px; color: var(--muted); }
+#period-block a { color: var(--accent); }
+
+/* Penalties */
+.penalties .table { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+.penalties .table > tbody > tr > td, .penalties .table > thead > tr > th { border-color: rgba(255,255,255,0.06); }
+.penalties a.btn.btn-primary { --btn-primary-bg: var(--accent); --btn-primary-bg-2: var(--accent); --btn-primary-shadow: none; }
+
+.progress { background: rgba(255,255,255,0.06); border-radius: 10px; border: 1px solid var(--border); }
+.progress-bar { background: linear-gradient(90deg, var(--accent), var(--accent-2)); box-shadow: 0 0 12px rgba(76,201,240,0.45); }
+
+/* Modal */
+.modal { background: rgba(7,10,20,0.72); backdrop-filter: blur(3px) saturate(88%); }
+.modal-open { overflow: hidden; }
+.modal-content { background: #101838; color: var(--text); border: 1px solid var(--border); border-top: 3px solid var(--accent); border-radius: 16px; box-shadow: 0 18px 60px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.06); }
+.modal-header, .modal-footer { border-color: rgba(255,255,255,0.08); }
+.modal-header { background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0)); border-top-left-radius: 16px; border-top-right-radius: 16px; }
+.modal-header .close { color: var(--text); text-shadow: none; opacity: .8; font-size: 28px; line-height: 1; padding: 4px 8px; margin-top: -6px; }
+.modal-header .close:hover, .modal-header .close:focus { color: #fff; opacity: 1; outline: none; }
+.modal .btn-danger { background: linear-gradient(180deg, #ff7575, #ef476f); border: none; }
+.modal.fade .modal-dialog { transform: translateY(8px) scale(0.985); opacity: 0; transition: transform .18s cubic-bezier(.2,.7,.2,1), opacity .18s ease; }
+.modal.in .modal-dialog { transform: translateY(0) scale(1); opacity: 1; }
+
+/* Tabs */
+.nav-tabs>li>a { background: #1b2446; border: 1px solid var(--border); color: var(--muted); }
+.nav-tabs>li.active>a { background: #242f5c !important; color: var(--text) !important; }
+
+/* Connection overlay (shared with display page) */
+#conn-overlay { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 9999; }
+#conn-overlay .overlay-bg { position: absolute; inset: 0; background: rgba(0,0,0,0.75); }
+#conn-overlay .overlay-card { position: relative; z-index: 1; background: rgba(10,10,30,0.95); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow); padding: 20px 26px; min-width: 320px; text-align: center; color: var(--text); }
+#conn-overlay .overlay-title { font-size: 28px; font-weight: 800; letter-spacing: 0.05em; margin-bottom: 6px; }
+#conn-overlay .overlay-text { font-size: 16px; opacity: 0.9; }
+#conn-overlay .overlay-note { margin-top: 8px; font-size: 14px; opacity: 0.8; }
+
+/* Power control */
+#power-control { display: flex; align-items: center; gap: 10px; }
+
+@media (max-width: 992px) { .navbar-brand { transform: scale(0.8); transform-origin: left center; } }
 
 #home .score .digits,
 #away .score .digits {
@@ -141,5 +246,9 @@ h2 {
 #new-game {
     float: right;
 }
+
+/* New Game dialog: left-align labels to reduce wrapping */
+#new-game-dialog .control-label { text-align: left; }
+#new-game-dialog .help-block { white-space: normal; }
 
 

--- a/src/main/dist/web/index.html
+++ b/src/main/dist/web/index.html
@@ -71,10 +71,11 @@
         <a data-toggle="modal" href="#add-penalty" class="penalty btn btn-primary" data-team="home">Penalty</a>
         <table class="table table-condensed">
           <tr>
-            <th>Period</th><th>#</th><th>Min</th><th>Off Ice</th><th>Start</th><th>Remaining</th><th>&nbsp;</th>
+            <th>Period</th><th>Player #</th><th>Remaining</th><th>&nbsp;</th>
           </tr>
           <tbody class="list"></tbody>
-          <tr><td colspan="3"></td></tr>
+          <tbody class="placeholders"></tbody>
+          <tr><td colspan="4"></td></tr>
         </table>
       </div>
     </div>
@@ -101,8 +102,8 @@
       <div id="period-block">
         <span>Period</span>
         <div id="period"><div class="digits"><div class="digit">0</div></div></div>
-        <a href="javascript:" class="period-up"><span class="glyphicon glyphicon-chevron-up"></span></a>
-        <a href="javascript:" class="period-down"><span class="glyphicon glyphicon-chevron-down"></span></a>
+        <a href="javascript:" class="period-up"><span class="glyphicon glyphicon-plus"></span></a>
+        <a href="javascript:" class="period-down"><span class="glyphicon glyphicon-minus"></span></a>
       </div>
     </div>
 
@@ -123,8 +124,8 @@
           <div class="section-label">Shots</div>
           <div id="away-shots" class="shots-counter">0</div>
           <div class="btn-row">
-            <button data-team="away" class="shots-down btn btn-default btn-sm">-</button>
             <button data-team="away" class="shots-up btn btn-info">+Shot</button>
+            <button data-team="away" class="shots-down btn btn-default btn-sm">-</button>
           </div>
         </div>
       </div>
@@ -133,10 +134,11 @@
         <a data-toggle="modal" href="#add-penalty" class="btn btn-primary" data-team="away">Penalty</a>
         <table class="table table-condensed">
           <tr>
-            <th>Period</th><th>#</th><th>Min</th><th>Off Ice</th><th>Start</th><th>Remaining</th><th>&nbsp;</th>
+            <th>Period</th><th>Player #</th><th>Remaining</th><th>&nbsp;</th>
           </tr>
           <tbody class="list"></tbody>
-          <tr><td colspan="3"></td></tr>
+          <tbody class="placeholders"></tbody>
+          <tr><td colspan="4"></td></tr>
         </table>
       </div>
     </div>
@@ -144,6 +146,33 @@
 </div>
 
 <!-- Dialogs (exactly as before) -->
+<div class="modal fade" id="penalty-details">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Penalty Details</h4>
+      </div>
+      <div class="modal-body">
+        <table class="table table-condensed">
+          <tbody>
+          <tr><th>Team</th><td id="pd-team"></td></tr>
+          <tr><th>Period</th><td id="pd-period"></td></tr>
+          <tr><th>Player #</th><td id="pd-player"></td></tr>
+          <tr><th>Duration</th><td id="pd-duration"></td></tr>
+          <tr><th>Off Ice</th><td id="pd-off"></td></tr>
+          <tr><th>Start</th><td id="pd-start"></td></tr>
+          <tr><th>Remaining</th><td id="pd-remaining"></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+  </div>
+
 <div class="modal fade" id="add-penalty">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -168,7 +197,14 @@
           <div class="penalty-time form-group">
             <label for="add-penalty-time" class="col-lg-6 control-label">Time</label>
             <div class="col-lg-3">
-              <input id="add-penalty-time" class="form-control input-sm" value="3:00" type="text" size="1"/>
+              <input id="add-penalty-time" class="form-control input-sm" value="2:00" type="text" size="1"/>
+            </div>
+            <div class="col-lg-12" style="margin-top:6px">
+              <a href="#" class="btn btn-default btn-xs" data-action="set-value" data-target="#add-penalty-time" data-value="2:00">2:00</a>
+              <a href="#" class="btn btn-default btn-xs" data-action="set-value" data-target="#add-penalty-time" data-value="5:00">5:00</a>
+              <a href="#" class="btn btn-default btn-xs" data-action="set-value" data-target="#add-penalty-time" data-value="10:00">10:00</a>
+              <span class="help-inline" style="margin-left:8px"></span>
+              <a href="#" class="btn btn-info btn-xs" id="add-penalty-2plus10" title="Add a 2-minute minor plus a 10-minute misconduct">2+10</a>
             </div>
           </div>
           <div class="penalty-clock form-group">
@@ -349,20 +385,21 @@
                 <!-- Ends at time-of-day input (primary) -->
                 <div id="rec_ends_group" class="period-form form-group">
                   <label for="rec_ends_at" class="col-lg-6 control-label">Ice Time Ends At</label>
-                  <div class="col-lg-12"><span class="help-block" style="margin:0">Quarter-hour increments (rounded up)</span></div>
-                  <div class="col-lg-6 col-lg-offset-6">
+                  <div class="col-lg-6">
                     <select id="rec_ends_at" class="form-control input-sm"></select>
                   </div>
+                  <div class="col-lg-12"><span class="help-block" style="margin:0">What time are you off the ice?</span></div>
+                  <div class="col-lg-12"><div id="rec-last-buzzer" class="help-block" style="margin:0"></div></div>
                 </div>
 
                 <!-- Duration minutes input (derived; editable) -->
                 <div id="rec_minutes_group" class="period-form form-group">
                   <label for="rec_minutes" class="col-lg-6 control-label">Game length in Minutes</label>
+                  <div class="col-lg-2"><input id="rec_minutes" class="form-control input-sm" type="text" maxlength="3" size="3" value="90"/></div>
                   <div class="col-lg-12">
                     <div id="rec-divisible-hint" class="help-block" style="margin:0"></div>
                     <div id="rec-split-hint" class="help-block" style="margin:0"></div>
                   </div>
-                  <div class="col-lg-2 col-lg-offset-6"><input id="rec_minutes" class="form-control input-sm" type="text" maxlength="3" size="3" value="60"/></div>
                 </div>
 
                 <!-- Shift buzzer: minutes + seconds with +/- controls -->

--- a/src/main/dist/web/js/scoreboard-main.js
+++ b/src/main/dist/web/js/scoreboard-main.js
@@ -24,7 +24,9 @@ const updatePenalties = (team, penalties) => {
       let remaining = p.time;
       if (p.startTime > 0) remaining = p.time - p.elapsed;
       if (remaining > 0) {
-        const pd = digits2(Number(p.playerNumber) || 0);
+        const serving = (p.servingPlayerNumber != null && p.servingPlayerNumber !== undefined && Number(p.servingPlayerNumber) !== 0)
+          ? Number(p.servingPlayerNumber) : Number(p.playerNumber);
+        const pd = digits2(serving || 0);
         $('.digit.tens', player).textContent = pd[0];
         $('.digit.ones', player).textContent = pd[1];
 

--- a/src/main/java/canfield/bia/hockey/scoreboard/io/ScoreboardAdapterImpl.java
+++ b/src/main/java/canfield/bia/hockey/scoreboard/io/ScoreboardAdapterImpl.java
@@ -374,7 +374,8 @@ public class ScoreboardAdapterImpl implements ScoreboardAdapter {
           b[index++] = (byte) 0xFF;
           b[index++] = (byte) 0xFF;
         } else {
-          int player = penalty.getPlayerNumber();
+          int serving = penalty.getServingPlayerNumber();
+          int player = serving != 0 ? serving : penalty.getPlayerNumber();
           b[index++] = digit(10, player, ZERO_VALUE_EMPTY);
           b[index++] = digit(1, player);
         }


### PR DESCRIPTION
 Summary

  - Improve penalty handling and rec game flow: serving indicators, 2+10 support, and end-of-rec 5‑minute rounding.
  - Tighten control UI feedback with a connection overlay and minor UI polish.

  What Changed

  - src/main/dist/web/index.html: Add penalty/serving placeholders and UI hooks; wire overlay container.
  - src/main/dist/web/css/index.css: Styles for connection overlay and updated penalty states.
  - src/main/dist/web/js/main.js: Core logic for penalties (2+10), serving state, and rec 5‑minute end rounding; overlay behavior on connection loss.
  - src/main/dist/web/js/scoreboard-main.js: Integrate new UI hooks.
  - src/main/java/canfield/bia/scoreboard/io/ScoreboardAdapterImpl.java: Minor tidy to align with UI behavior (no breaking changes).

  Why

  - Rec/Drop‑In games needed consistent time rounding at game end to nearest 5 minutes.
  - Operators requested clearer visibility into which penalties are actively serving, including 2+10 combos.
  - Improve operator confidence with a visible connection status overlay when the control UI disconnects.

  UI Notes

  - Serving penalties highlight when actively counting down.
  - 2+10 shows minor serving while misconduct runs separately; prevents accidental clock coupling.
  - Connection overlay appears on socket disconnect, fades when reconnected.

  Test Plan

  - Build and unit tests:
      - ./gradlew build (passes)
      - ./gradlew test (should pass; headless-friendly)
  - Manual UX verification (local):
      - ./gradlew run (service on 8080, WS on 8081)
      - Start a Rec/Drop‑In game; set end time at 58:01, verify rounding to 60:00; at 57:59, verify stays under 60.
      - Add penalties:
      - Minor (2:00) — verify serving highlight and decrement.
      - 2+10 — verify 2:00 serves while 10:00 misconduct runs independently; UI state remains consistent across stops/starts.
  - Disconnect network or stop WS temporarily — overlay appears; reconnect clears it.
  - Cross-browser sanity: Chrome, Edge latest.

  Backward Compatibility / Risk

  - No API/DB schema changes.
  - UI-only plus small non-breaking Java tidy; low risk.
  - Penalty logic touches are localized to main.js; guarded by existing UI states.

  Screenshots / GIFs

  - Add before/after for:
      - Serving highlight during penalties
      - 2+10 display
      - Connection overlay visible vs. connected
      - Rec end rounding confirmation dialog/toast (if applicable)

  Rollout

  - Safe to ship; no config changes required.
  - Monitor operator feedback during first rec session post-deploy.

  Follow‑Ups

  - Add unit tests around time rounding edge cases and 2+10 transitions.
  - Consider a small tooltip/help for 2+10 behavior in UI.
  - Optional: telemetry for connection drop counts to quantify stability.