### PR TITLE
ci: publish Windows artifacts to GitHub Releases on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release-windows:
+    name: Build (Windows) and Publish Release
+    runs-on: windows-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Verify Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Build distribution artifacts (skip tests)
+        shell: pwsh
+        run: |
+          ./gradlew.bat --version
+          ./gradlew.bat clean shadowJar jpackageFullJre appImageZip -x test --no-daemon --stacktrace
+
+      - name: Collect artifacts
+        id: artifacts
+        shell: pwsh
+        run: |
+          Write-Host "Listing built files:"
+          Get-ChildItem -Force build/libs -ErrorAction SilentlyContinue | Format-List || $true
+          Get-ChildItem -Force build/jpackage -ErrorAction SilentlyContinue | Format-List || $true
+          Get-ChildItem -Force build/artifacts -ErrorAction SilentlyContinue | Format-List || $true
+          $jar_all = (Get-ChildItem build/libs -Filter *-all.jar -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }) -join ' '
+          $app_zip = (Get-ChildItem build/artifacts -Filter *.zip -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }) -join ' '
+          $installer = (Get-ChildItem build/jpackage -Filter *.exe -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }) -join ' '
+          "jar_all=$jar_all" >> $env:GITHUB_OUTPUT
+          "app_zip=$app_zip" >> $env:GITHUB_OUTPUT
+          "installer=$installer" >> $env:GITHUB_OUTPUT
+
+      - name: Create GitHub Release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          prerelease: false
+          files: |
+            ${{ steps.artifacts.outputs.jar_all }}
+            ${{ steps.artifacts.outputs.app_zip }}
+            ${{ steps.artifacts.outputs.installer }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 
 # put stuff you don't want checked in here
 local/
+tools/
 
 /out/
 /src/main/dist/scoreboard.properties


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds the Windows app-image and uploads release assets on tag pushes.\n\nHighlights\n- Runs on  with Java 21 (Temurin).\n- Generates fat jar via .\n- Packages a Windows app-image with  and zips it ().\n- Creates/updates a GitHub Release for  tags and uploads assets:\n  - \n  -  (app-image zip)\n  -  if present.\n\nYou can test by pushing a tag like .\n\nNotes\n- Tests are skipped in the release job to avoid headless UI flakiness. We can add a separate CI workflow to run tests on PRs and .